### PR TITLE
Add Tasks

### DIFF
--- a/cartesius/config/default.yaml
+++ b/cartesius/config/default.yaml
@@ -27,7 +27,7 @@ pooling: "first"
 adjacent_only: True
 
 # Tasks
-tasks: ["area", "perimeter", "size", "concavity", "min_clear", "centroid"]
+tasks: ["area", "perimeter", "size", "concavity", "min_clear", "centroid", "ombr_ratio", "aspect_ratio", "opening_ratio"]
 tasks_scales: [100, 1, 50, 20, 20, 50]
 task_dropout: 0.1
 

--- a/cartesius/tasks.py
+++ b/cartesius/tasks.py
@@ -176,5 +176,4 @@ TASKS = {
     "ombr_ratio": GuessOmbrRatio,
     "aspect_ratio": GuessAspectRatio,
     "opening_ratio": GuessOpeningRatio,
-    "longest_edges": GuessLongestThreeEdges
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,6 +86,9 @@ List of tasks currently implemented :
 * **`concavity`** : Predict the "concavity" of the polygon. Concavity is defined as the area of the polygon divided by the area of its convex hull. It represents "how much concave a polygon is".
 * **`min_clear`** : Predict the minimum clearance of the polygon. The minimum clearance is the smallest distance by which a node should be moved to produce an invalid geometry.
 * **`centroid`** : Predict the x and y coordinates of the centroid of the polygon.
+* **`ombr_ratio`** : Predict "oriented minimum bounding rectangle ratio" of the polygon. OMBR ratio is defined as the area of the polygon divided by the area of its oriented minimum bounding rectangle. It represents "how close the polygon is to a rectangle".
+* **`aspect_ratio`** : Predict "oriented minimum bounding rectangle aspect ratio" of the polygon. OMBR aspect ratio is defined as the length of shorter line divided by longer line of the OMBR. It represents wideness of the polygon.
+* **`opening_ratio`** : Predict "opening ratio" of the polygon. Opening ratio is defined as the area of the opening applied polygon divided by the area of the original polygon. It represents "how much polygon have useful space that is wide enough".
 
 ## Configuration
 


### PR DESCRIPTION
## 🔍️ Description

Added four tasks that is meaningful for small-housing: GuessOmbrRatio, GuessAspectRatio, GuessOpeningRatio, GuessLongestThreeEdges. 
For proper training on GuessLongestThreeEdges, modification on model is needed. It will be handled on other PR.

1. GuessOmbrRatio

Polygon area / OMBR area
Similar to GuessConcavity, but its value is smaller than Guessconcavity.
To compute concavity, we divide original area with the area of convex hull.
Instead of convex hull, we use oriented minimum bounding rectangle to compute this measure.
Purpose of measuring this is to evaluate rectangleness of polygon

2. GuessAspectRatio

OMBR min edge length / OMBR max edge length
Aspect ratio of oriented minimum bounding rectangle of polygon.
Length of shorter edge is divided by that of longer edge. (In order to get value between 0~1)
Purpose of measuring this is to evaluate wideness of polygon

3. GuessOpeningRatio

Geometry area after opening by 25 / Polygon area
Opening operation is sequence of erosion and dilation.
Purpose of measuring this is to evaluate deadspace of polygon.

4. GuessLongestThreeEdges

Three edge indices that is sorted by its length
Not always, but as usual, to use longer edge as parking edge is desired on our problem.
Purpose of measuring this is to evaluate dominant edge of polygon.

## 🧐 Context

For Small-housing problem, we frequently use above informations, so these kind of tasks can be meaningful on 

## 🏷️ Tickets

<!--- List JIRA tickets or Github issues associated to this PR here --->
* SHE-1648

## ⚠️ Side-effects

<!--- Any side-effects or shortcomings reviewers should be aware of ? --->
GuessLongestThreeEdges task works without error, but not sure it can be trained properly.
This task is to generate longest three segment indices with a sequence, so, actually it needs entity head and cross entropy loss.
Instead, currently it designed to generate indices directly, but as relational inductive bias aspect, I think it's hard to train.
For future work, some features have to be added to handle this.
So, I don't like to add this task as our official task.

## ✅ How this was tested ?

Local test with plotting has been passed
E2E Test passed
Lint passed

## 🌱 Checklist

<!--- Add here any task left to do before the PR is ready for review / merging --->
- [x] Perform self-review of my own code
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Update the documentation accordingly to the new code
- [x] Lint / format the code
- [ ] Update existing tests / Add new tests
- [x] Tests are passing locally