### PR TITLE
:zap: Polygon generation speed improvement

### DIFF
--- a/cartesius/data.py
+++ b/cartesius/data.py
@@ -116,30 +116,22 @@ class PolygonDataset(Dataset):
         spikeyness = spikeyness * avg_radius
 
         # Generate n angle steps
-        angle_steps = []
         lower = (2 * math.pi / n_vert) - irregularity
         upper = (2 * math.pi / n_vert) + irregularity
-        s = 0
-        for i in range(n_vert):
-            tmp = random.uniform(lower, upper)
-            angle_steps.append(tmp)
-            s = s + tmp
+        angle_steps = np.random.uniform(lower, upper, n_vert)
+        s = angle_steps.sum()
 
         # Normalize the steps so that point 0 and point n+1 are the same
         k = s / (2 * math.pi)
-        for i in range(n_vert):
-            angle_steps[i] = angle_steps[i] / k
+        angle_steps = angle_steps / k
 
         # Now generate the points
-        points = []
         angle = random.uniform(0, 2 * math.pi)
-        for i in range(n_vert):
-            r_i = np.clip(random.gauss(avg_radius, spikeyness), 0, 2 * avg_radius)
-            x = x_ctr + r_i * math.cos(angle)
-            y = y_ctr + r_i * math.sin(angle)
-            points.append((x, y))
-
-            angle = angle + angle_steps[i]
+        angles = np.cumsum(angle_steps) + angle
+        rs = np.clip(np.random.normal(avg_radius, spikeyness, n_vert), 0, 2 * avg_radius)
+        xs = x_ctr + np.multiply(rs, np.cos(angles))
+        ys = y_ctr + np.multiply(rs, np.sin(angles))
+        points = [(x, y) for x, y in zip(xs, ys)]
 
         if len(points) == 1:
             return Point(points)


### PR DESCRIPTION
<!--- The title of your PR should be short, focused, and to the point. Usually, the title is a complete sentence written as it was an order (imperative sentence) --->

## 🔍️ Description

<!--- Longer description, providing details that the title couldn't provide. Feel free to use images --->

Cuts down time for generating polygons greatly.

With an arbitrary setup of

```python
n_vert = 10
irregularity = random.random() * 2 * math.pi / n_vert
avg_radius = 10
spikeyness = random.random()
x_ctr = random.uniform(-10, 10)
y_ctr = random.uniform(-10, 10)
```

on my local machine, the results are

```python
%%timeit

# Generate n angle steps
angle_steps = []
lower = (2 * math.pi / n_vert) - irregularity
upper = (2 * math.pi / n_vert) + irregularity
s = 0
for _ in range(n_vert):
    tmp = random.uniform(lower, upper)
    angle_steps.append(tmp)
    s = s + tmp

# Normalize the steps so that point 0 and point n+1 are the same
k = s / (2 * math.pi)
for i in range(n_vert):
    angle_steps[i] = angle_steps[i] / k

# Now generate the points
points = []
angle = random.uniform(0, 2 * math.pi)
for i in range(n_vert):
    r_i = np.clip(random.gauss(avg_radius, spikeyness), 0, 2 * avg_radius)
    x = x_ctr + r_i * math.cos(angle)
    y = y_ctr + r_i * math.sin(angle)
    points.append((x, y))

    angle = angle + angle_steps[i]
```

```
133 µs ± 3.14 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

for the original code and

```python
%%timeit

# Generate n angle steps
lower = (2 * math.pi / n_vert) - irregularity
upper = (2 * math.pi / n_vert) + irregularity
angle_steps = np.random.uniform(lower, upper, n_vert)
s = angle_steps.sum()

# Normalize the steps so that point 0 and point n+1 are the same
k = s / (2 * math.pi)
angle_steps = angle_steps / k

# Now generate the points
angle = random.uniform(0, 2 * math.pi)
angles = np.cumsum(angle_steps) + angle
rs = np.clip(np.random.normal(avg_radius, spikeyness, n_vert), 0, 2 * avg_radius)
xs = x_ctr + np.multiply(rs, np.cos(angles))
ys = y_ctr + np.multiply(rs, np.sin(angles))
points = [(x, y) for x, y in zip(xs, ys)]
```

```
29.5 µs ± 602 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

for the new version.

The discrepancy grows pretty fast as `n_vert` grows. With `n_vert = 100`, I get

```
1.29 ms ± 52 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

and

```
42.4 µs ± 894 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

respectively. 😶

## 🧐 Context

<!--- Provide additional context, like why this PR is needed (what was wrong with previous code) --->

While skimming the code by chance, thought I'd make an improvement on what seemed pretty inefficient. 😗

## 🏷️ Tickets

<!--- List JIRA tickets or Github issues associated to this PR here --->
* N/A

## ⚠️ Side-effects

<!--- Any side-effects or shortcomings reviewers should be aware of ? --->

None that I can think of.

## ✅ How this was tested ?

<!--- Describe the tests you ran to verify your changes. It's also the place to provide instructions for reproducing the tests / relevant details of the test configuration. --->

I'm not sure about its relevance, but the result of the provided unit test was at least all green. 🙄

## 🌱 Checklist

<!--- Add here any task left to do before the PR is ready for review / merging --->
- [ ] Perform self-review of my own code
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Update the documentation accordingly to the new code
- [ ] Lint / format the code
- [ ] Update existing tests / Add new tests
- [ ] Tests are passing locally